### PR TITLE
fix: break Connection ↔ SwiftWebServer retain cycle (#6)

### DIFF
--- a/Sources/SwiftWebServer/Core/Connection.swift
+++ b/Sources/SwiftWebServer/Core/Connection.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class Connection {
     var nativeSocketHandle: Int32
-    var server: SwiftWebServer?
+    weak var server: SwiftWebServer?
 
     init(nativeSocketHandle: Int32, server: SwiftWebServer) {
         self.nativeSocketHandle = nativeSocketHandle

--- a/Tests/SwiftWebServerTests/ConnectionRetainCycleTests.swift
+++ b/Tests/SwiftWebServerTests/ConnectionRetainCycleTests.swift
@@ -33,9 +33,9 @@ final class ConnectionRetainCycleTests: XCTestCase {
             // without performing real I/O. We're testing the object graph,
             // not socket behavior.
             connection = Connection(nativeSocketHandle: -1, server: server)
-            // Drop the static-dict entry so it doesn't pin the server
-            // transitively — the cycle under test is Connection.server,
-            // not the dictionary itself.
+            // Ensure the static dict is empty so it can't pin the server
+            // transitively if a prior test left state behind — the cycle
+            // under test is Connection.server, not the dictionary itself.
             SwiftWebServer.connections = [:]
         }
 

--- a/Tests/SwiftWebServerTests/ConnectionRetainCycleTests.swift
+++ b/Tests/SwiftWebServerTests/ConnectionRetainCycleTests.swift
@@ -1,0 +1,48 @@
+//
+//  ConnectionRetainCycleTests.swift
+//  SwiftWebServerTests
+//
+//  Regression tests for issue #6: Connection ↔ SwiftWebServer retain cycle.
+//
+
+import XCTest
+@testable import SwiftWebServer
+
+@MainActor
+final class ConnectionRetainCycleTests: XCTestCase {
+
+    override func tearDown() {
+        super.tearDown()
+        // Avoid bleeding state into other tests: a Connection's bg-queue
+        // disconnect path may have queued an async update to this dict.
+        SwiftWebServer.connections = [:]
+    }
+
+    /// With `Connection.server` held weakly, a live Connection must not
+    /// keep the SwiftWebServer alive after its owner drops the last
+    /// strong reference. Pre-fix (strong reference) this test fails:
+    /// `connection.server -> server` pinned the graph indefinitely.
+    func testConnectionHoldsServerWeakly() {
+        weak var weakServer: SwiftWebServer?
+        var connection: Connection?
+
+        autoreleasepool {
+            let server = SwiftWebServer()
+            weakServer = server
+            // Invalid socket handle: recv will fail quickly on the bg queue
+            // without performing real I/O. We're testing the object graph,
+            // not socket behavior.
+            connection = Connection(nativeSocketHandle: -1, server: server)
+            // Drop the static-dict entry so it doesn't pin the server
+            // transitively — the cycle under test is Connection.server,
+            // not the dictionary itself.
+            SwiftWebServer.connections = [:]
+        }
+
+        XCTAssertNil(
+            weakServer,
+            "Connection.server must be weak so SwiftWebServer can deallocate while a Connection is still alive"
+        )
+        XCTAssertNotNil(connection, "Sanity: the Connection itself is still alive in this scope")
+    }
+}


### PR DESCRIPTION
## Summary
- Mark `Connection.server` as `weak` so the static `SwiftWebServer.connections` dictionary no longer pins the server graph through its connections.
- `server` is already `Optional` and every call site already does `guard let server = self.server else { ... }` before use, so this is a near-zero-cost change.

## Why
Per #6, the cycle `SwiftWebServer.connections[address] -> Connection -> Connection.server -> SwiftWebServer` keeps the server alive (and pins its `routeHandlers` / middleware / closures) for as long as any connection is alive — masked in CLI / one-shot use, but observable as growing RSS in long-running apps that bring servers up and down.

## Test plan
- [x] `swift build` succeeds.
- [x] `swift test` — all 43 tests pass.
- [ ] Manual verification of the retain-cycle fix is hard to write deterministically without weak-tracking machinery; suggested follow-up is a memory-graph check in CodingPlanKit's `LocalCallbackServer` lifecycle.

Closes #6