### PR TITLE
ci: add CI workflow to build and test on push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
   test:
     name: Swift on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+
+permissions:
+  contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Swift on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Build
+        run: swift build -v
+
+      - name: Test
+        run: swift test -v


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` that runs `swift build` + `swift test` on push to `main` and on pull requests.
- Matrix runs on `macos-14` and `macos-15` with `fail-fast: false` to surface per-OS regressions.
- Adds a concurrency group so older runs on the same ref are cancelled when new commits land.

## Why
Closes the gap raised in #11: until now the only workflow was `claude.yml` (the @claude review bot), so nothing was actually compiling the package or running the test suite when commits hit `main` or PRs. That left the existing 46 tests un-enforced in CI — regressions could merge unchecked.

## Test plan
- [x] `swift build` passes locally (worktree, Swift 6.3.1 / macOS 26).
- [x] `swift test` passes locally: 46 tests, 0 failures.
- [ ] First CI run on this PR will demonstrate the workflow itself works on `macos-14` and `macos-15`.

Closes #11