### PR TITLE
ci: refresh Dependabot config (PR limits + labels)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "swift"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
## Summary
- Adds `open-pull-requests-limit: 5` and `labels` to both ecosystems in `.github/dependabot.yml`.
- Modifying the config also forces Dependabot to re-evaluate, which clears any stale `Dependabot couldn't find a <anything>.yml` warning that may have lingered from when the config was added before any workflow file existed.

## Test plan
- [ ] Merge and confirm the Dependabot page on Insights → Dependency graph → Dependabot has no warning for either ecosystem.
- [ ] Confirm new Dependabot PRs (when they appear) carry the new labels.