### PR TITLE
ci: drop redundant macos-14 runner from matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,9 @@ concurrency:
 
 jobs:
   test:
-    name: Swift on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Swift on macos-15
+    runs-on: macos-15
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-14, macos-15]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Collapse the CI test matrix from `[macos-14, macos-15]` to a single `macos-15` runner.
- Halves macOS runner-minutes per push/PR; the previous matrix wasn't actually testing pinned Swift versions — each image runs against whatever default Xcode it currently ships, which drifts silently over time.
- If we later want to verify the Swift 5.10 floor declared in `Package.swift`, the right fix is a separate job that `xcode-select`s a pinned older Xcode, not an unpinned matrix.

## Test plan

- [ ] CI runs on this PR and the single `Swift on macos-15` job goes green (`swift build -v` + `swift test -v`).
- [ ] Confirm no other workflow references the removed `macos-14` runner.